### PR TITLE
Add gunicorn socket override for docker image

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -2,8 +2,7 @@ from multiprocessing import cpu_count
 from os import environ
 
 
-
-bind = '0.0.0.0:' + environ.get('PORT', '5000')
+bind = environ.get('SOCKET_OVERRIDE', '0.0.0.0:' + environ.get('PORT', '5000'))
 max_requests = 1000
 worker_class = "uvicorn.workers.UvicornWorker"
 workers = cpu_count()

--- a/readme.md
+++ b/readme.md
@@ -19,3 +19,9 @@ To allow different clients:
 ```bash
     docker run --rm -p 5000:5000 --name=fcs_server -e CLIENTS="http://client1,http://client2" fcs_server
 ```
+
+To run and connect to a unix socket:
+
+```bash
+    docker run --rm -e "SOCKET_OVERRIDE=unix:<YOURPATH/YOURSOCKET.sock>" -v <YOURPATH>:<YOURPATH> --name=fcs_server fcs_server
+```


### PR DESCRIPTION
Allows for the gunicorn socket bind to be overriden with a string contained in environment variable SOCKET_OVERRIDE.

This is added to allow the standard docker image to be used in a deployment where a proxy outside of the container connects to gunicorn via a unix socket.

For example:
docker run --rm -e "SOCKET_OVERRIDE=unix:<YOURPATH/YOURSOCKET.sock>" -v <YOURPATH>:<YOURPATH> --name=fcs_server fcs_server